### PR TITLE
Update component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -2,7 +2,7 @@
   "name": "reduce",
   "repo": "redventures/reduce",
   "description": "Array reduce component",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "keywords": ["array", "reduce"],
   "dependencies": {},
   "development": {},


### PR DESCRIPTION
new component builder v1.x, fails to download reduce dependencies cause the tagged version 1.0.1 and the component version don't match.

(see https://github.com/RedVentures/reduce/blob/1.0.1/component.json#L5)

could you republish the tagged version, or create a new one so that the tagged contain the component.json with the same version.
